### PR TITLE
[WIP] Add product dev related skills

### DIFF
--- a/components/SnowflakeApp.js
+++ b/components/SnowflakeApp.js
@@ -59,11 +59,12 @@ const emptyState = (): SnowflakeAppState => {
       'CAREER_DEVELOPMENT': 0,
       'ORG_DESIGN': 0,
       'WELLBEING': 0,
-      'ACCOMPLISHMENT': 0,
       'MENTORSHIP': 0,
-      'EVANGELISM': 0,
       'RECRUITING': 0,
-      'COMMUNITY': 0
+      'COMMUNITY': 0,
+      'EXPERIMENTATION': 0,
+      'MARKET': 0,
+      'STRATEGY': 0
     },
     focusedTrackId: 'SERVERS'
   }
@@ -84,11 +85,12 @@ const defaultState = (): SnowflakeAppState => {
       'CAREER_DEVELOPMENT': 0,
       'ORG_DESIGN': 0,
       'WELLBEING': 0,
-      'ACCOMPLISHMENT': 0,
       'MENTORSHIP': 0,
-      'EVANGELISM': 0,
       'RECRUITING': 0,
-      'COMMUNITY': 0
+      'COMMUNITY': 0,
+      'EXPERIMENTATION': 0,
+      'MARKET': 0,
+      'STRATEGY': 0
     },
     focusedTrackId: 'SERVERS'
   }

--- a/constants.js
+++ b/constants.js
@@ -51,8 +51,7 @@ export const titles = [
   {label: 'Tech Leader', minPoints: 88, maxPoints: 115},
   {label: 'Engineering Manager', minPoints: 88, maxPoints: 115},
   {label: 'Software Architect', minPoints: 116},
-  {label: 'Head of Engineering', minPoints: 116},
-  {label: 'Product Manager', minPoints: 130 }
+  {label: 'Head of Engineering', minPoints: 116}
 ]
 
 export const pointsToLevels = {

--- a/constants.js
+++ b/constants.js
@@ -10,16 +10,18 @@ import INITIATIVE from './trackData/initiative.json'
 import CAREER_DEVELOPMENT from './trackData/careerDevelopment.json'
 import ORG_DESIGN from './trackData/orgDesign.json'
 import WELLBEING from './trackData/wellbeing.json'
-import ACCOMPLISHMENT from './trackData/accomplishment.json'
 import MENTORSHIP from './trackData/mentorship.json'
-import EVANGELISM from './trackData/evangelism.json'
 import RECRUITING from './trackData/recruiting.json'
 import COMMUNITY from './trackData/community.json'
+import EXPERIMENTATION from './trackData/experimentation.json'
+import MARKET from './trackData/market.json'
+import STRATEGY from './trackData/strategy.json'
 
 export type TrackId = 'WEB_CLIENT' | 'FOUNDATIONS' | 'SERVERS' |
   'PROJECT_MANAGEMENT' | 'COMMUNICATION' | 'CRAFT' | 'INITIATIVE' |
-  'CAREER_DEVELOPMENT' | 'ORG_DESIGN' | 'WELLBEING' | 'ACCOMPLISHMENT' |
-  'MENTORSHIP' | 'EVANGELISM' | 'RECRUITING' | 'COMMUNITY'
+  'CAREER_DEVELOPMENT' | 'ORG_DESIGN' | 'WELLBEING' |
+  'MENTORSHIP' | 'RECRUITING' | 'COMMUNITY' |
+  'EXPERIMENTATION' | 'MARKET' | 'STRATEGY'
 export type Milestone = 0 | 1 | 2 | 3 | 4 | 5
 
 export type MilestoneMap = {
@@ -33,11 +35,12 @@ export type MilestoneMap = {
   'CAREER_DEVELOPMENT': Milestone,
   'ORG_DESIGN': Milestone,
   'WELLBEING': Milestone,
-  'ACCOMPLISHMENT': Milestone,
   'MENTORSHIP': Milestone,
-  'EVANGELISM': Milestone,
   'RECRUITING': Milestone,
-  'COMMUNITY': Milestone
+  'COMMUNITY': Milestone,
+  'EXPERIMENTATION': Milestone,
+  'MARKET': Milestone,
+  'STRATEGY': Milestone,
 }
 export const milestones = [0, 1, 2, 3, 4, 5]
 
@@ -48,7 +51,8 @@ export const titles = [
   {label: 'Tech Leader', minPoints: 88, maxPoints: 115},
   {label: 'Engineering Manager', minPoints: 88, maxPoints: 115},
   {label: 'Software Architect', minPoints: 116},
-  {label: 'Head of Engineering', minPoints: 116}
+  {label: 'Head of Engineering', minPoints: 116},
+  {label: 'Product Manager', minPoints: 130 }
 ]
 
 export const pointsToLevels = {
@@ -91,18 +95,20 @@ type Tracks = {|
   'CAREER_DEVELOPMENT': Track,
   'ORG_DESIGN': Track,
   'WELLBEING': Track,
-  'ACCOMPLISHMENT': Track,
   'MENTORSHIP': Track,
-  'EVANGELISM': Track,
   'RECRUITING': Track,
-  'COMMUNITY': Track
+  'COMMUNITY': Track,
+  'EXPERIMENTATION': Track,
+  'MARKET': Track,
+  'STRATEGY': Track
 |}
 
 export const tracks: Tracks = {
                                 WEB_CLIENT, SERVERS, FOUNDATIONS, 
                                 PROJECT_MANAGEMENT, COMMUNICATION, CRAFT, INITIATIVE, 
-                                CAREER_DEVELOPMENT, ORG_DESIGN, WELLBEING, ACCOMPLISHMENT,
-                                MENTORSHIP, EVANGELISM, RECRUITING, COMMUNITY
+                                CAREER_DEVELOPMENT, ORG_DESIGN, WELLBEING,
+                                MENTORSHIP, RECRUITING, COMMUNITY,
+                                EXPERIMENTATION, MARKET, STRATEGY
                               };
 
  
@@ -119,7 +125,7 @@ export const categoryPointsFromMilestoneMap = (milestoneMap: MilestoneMap) => {
   trackIds.forEach((trackId) => {
     const milestone = milestoneMap[trackId]
     const categoryId = tracks[trackId].category
-    let currentPoints = pointsByCategory.get(categoryId) || 0
+      let currentPoints = pointsByCategory.get(categoryId) || 0
     if (milestone === 0){
       pointsByCategory.set(categoryId, currentPoints + 0)
     }
@@ -147,7 +153,7 @@ export const totalPointsFromMilestoneMap = (milestoneMap: MilestoneMap): number 
 
 export const categoryColorScale = d3.scaleOrdinal()
   .domain(categoryIds)
-  .range(['#007DA4', '#C4D600', '#FB8B24', '#D90368'])
+    .range(['#8ac384', '#f3c65e', '#f78c63', '#6b8ba3', '#ba5479'])
 
 
 export const eligibleTitles = (milestoneMap: MilestoneMap): string[] => {

--- a/constants.js
+++ b/constants.js
@@ -48,10 +48,12 @@ export const titles = [
   {label: 'Junior Software Engineer', minPoints: 0, maxPoints: 24},
   {label: 'Software Engineer', minPoints: 25, maxPoints: 53},
   {label: 'Senior Software Engineer', minPoints: 54, maxPoints: 87},
-  {label: 'Tech Leader', minPoints: 88, maxPoints: 115},
-  {label: 'Engineering Manager', minPoints: 88, maxPoints: 115},
-  {label: 'Software Architect', minPoints: 116},
-  {label: 'Head of Engineering', minPoints: 116}
+  {label: 'Tech Leader', minPoints: 88, maxPoints: 159},
+  {label: 'Engineering Manager', minPoints: 88, maxPoints: 159},
+  {label: 'Product Owner', minPoints: 88, maxPoints: 159},
+  {label: 'Software Architect', minPoints: 160},
+  {label: 'Head of Engineering', minPoints: 160},
+  {label: 'Product Manager', minPoints: 160 }
 ]
 
 export const pointsToLevels = {
@@ -70,7 +72,7 @@ export const pointsToLevels = {
   '160': '5.2'
 }
 
-export const maxLevel = 192
+export const maxLevel = 1000
 
 export type Track = {
   displayName: string,
@@ -142,7 +144,7 @@ export const totalPointsFromMilestoneMap = (milestoneMap: MilestoneMap): number 
   var sum = 0;
   trackIds.map(trackId => {
     const milestone = milestoneMap[trackId]
-    if (milestone > 0) {
+      if (milestone > 0) {
       sum = sum + tracks[trackId].milestones[milestone-1].points
     }
   })
@@ -156,7 +158,7 @@ export const categoryColorScale = d3.scaleOrdinal()
 
 
 export const eligibleTitles = (milestoneMap: MilestoneMap): string[] => {
-  const totalPoints = totalPointsFromMilestoneMap(milestoneMap)
+    const totalPoints = totalPointsFromMilestoneMap(milestoneMap)
   var titleList = titles.filter(title => (title.minPoints === undefined || totalPoints >= title.minPoints)
                              && (title.maxPoints === undefined || totalPoints <= title.maxPoints))
     .map(title => title.label)

--- a/trackData/backend.json
+++ b/trackData/backend.json
@@ -3,7 +3,7 @@
     "category": "A",
     "description": "Develops expertise in server side engineering",
     "milestones": [{
-      "points": 1.5,
+      "points": 1,
       "summary": "Works effectively within established server side frameworks, following current best practices",
       "signals": [
         "Nice storytelling, code and commits are self explainable, facilitates code reviews by others",
@@ -46,7 +46,7 @@
       ]
     },
     {
-      "points": 4.5,
+      "points": 4,
       "summary": "Develops new instances of existing architecture, or minor improvements to existing architecture",
       "signals": [
         "Effectively reviews others' code",

--- a/trackData/experimentation.json
+++ b/trackData/experimentation.json
@@ -1,0 +1,41 @@
+{
+    "displayName": "Experimentation",
+    "category": "E",
+    "description": "Exploits experimentation to benefit innovative efforts and opportunities exploration",
+    "milestones": [{
+      "points": 1,
+      "summary": "",
+      "signals": [
+      ],
+      "examples": [
+      ]
+    }, {
+      "points": 3,
+      "summary": "",
+      "signals": [
+      ],
+      "examples": [
+      ]
+    }, {
+      "points": 6,
+      "summary": "",
+      "signals": [
+      ],
+      "examples": [
+      ]
+    }, {
+      "points": 12,
+      "summary": "",
+      "signals": [
+      ],
+      "examples": [
+      ]
+    }, {
+      "points": 20,
+      "summary": "",
+      "signals": [
+      ],
+      "examples": [
+      ]
+    }]
+  }

--- a/trackData/frontend.json
+++ b/trackData/frontend.json
@@ -4,7 +4,7 @@
     "category": "A",
     "description": "Develops expertise in web client technologies, such as HTML, CSS, and JavaScript",
     "milestones": [{
-        "points": 1.5,
+        "points": 1,
         "summary": "Works effectively within established web client architectures, following current best practices",
         "signals": [
             "Makes minor modifications to existing screens",
@@ -18,7 +18,7 @@
         ]
     },
     {
-        "points": 4.5,
+        "points": 4,
         "summary": "Develops new instances of existing architecture, or minor improvements to existing architecture\n",
         "signals": [
             "Makes sensible abstractions based on template and code patterns",

--- a/trackData/market.json
+++ b/trackData/market.json
@@ -1,0 +1,41 @@
+{
+    "displayName": "Market",
+    "category": "E",
+    "description": "Understands market competition and dynamics, and applies research, testing and validation to learn about needs and product opportunities",
+    "milestones": [{
+      "points": 1,
+      "summary": "",
+      "signals": [
+      ],
+      "examples": [
+      ]
+    }, {
+      "points": 4,
+      "summary": "",
+      "signals": [
+      ],
+      "examples": [
+      ]
+    }, {
+      "points": 8,
+      "summary": "",
+      "signals": [
+      ],
+      "examples": [
+      ]
+    }, {
+      "points": 16,
+      "summary": "",
+      "signals": [
+      ],
+      "examples": [
+      ]
+    }, {
+      "points": 24,
+      "summary": "",
+      "signals": [
+      ],
+      "examples": [
+      ]
+    }]
+  }

--- a/trackData/strategy.json
+++ b/trackData/strategy.json
@@ -1,0 +1,41 @@
+{
+    "displayName": "Strategy",
+    "category": "E",
+    "description": "Takes the market competition, technological constraints and innovation opportunities into account and maintains threads between short-term and long-term goals",
+    "milestones": [{
+      "points": 2,
+      "summary": "",
+      "signals": [
+      ],
+      "examples": [
+      ]
+    }, {
+      "points": 4,
+      "summary": "",
+      "signals": [
+      ],
+      "examples": [
+      ]
+    }, {
+      "points": 8,
+      "summary": "",
+      "signals": [
+      ],
+      "examples": [
+      ]
+    }, {
+      "points": 16,
+      "summary": "",
+      "signals": [
+      ],
+      "examples": [
+      ]
+    }, {
+      "points": 32,
+      "summary": "",
+      "signals": [
+      ],
+      "examples": [
+      ]
+    }]
+  }


### PR DESCRIPTION
This is adding some product development skills as tracks:
- Experimentation
- Market
- Strategy

and some related roles:
- [Product Owner](https://www.scaledagileframework.com/product-owner/) is a third branching path in career, next to Engineering Manager and Tech Lead.
- Product Manager is a next career step after Product Owner.

Note:
For this I'm removing Evangelism and Accomplishments which will be merged with Community and Org Design respectively as a follow up.